### PR TITLE
Refactor the retrieval of all users from JIRA

### DIFF
--- a/lib/jira/resource/user.rb
+++ b/lib/jira/resource/user.rb
@@ -5,30 +5,21 @@ module JIRA
     end
 
     class User < JIRA::Base
-      SMALLER_SAMPLE_SIZE = 100
+      MAX_RESULTS = 1000
 
       def self.singular_path(client, key, prefix = '/')
         collection_path(client, prefix) + '?username=' + key
       end
 
-      # This method is a bit of a hack. There is no way to get a list of all users in Jira, so we concatenate all of the project IDs
-      # and use the assignable users endpoint to get a list of users that can be assigned to all projects.
+      # Cannot retrieve more than 1,000 users through the api, please see: https://jira.atlassian.com/browse/JRASERVER-65089
       def self.all(client)
-        all_users           = []
-        grouped_project_ids = client.Project.all.map(&:key).uniq.each_slice(SMALLER_SAMPLE_SIZE).to_a
-
-        grouped_project_ids.each do |project_ids|
-          project_list = project_ids.join(",")
-          response     = client.get("#{client.options[:rest_base_path]}/user/assignable/multiProjectSearch?projectKeys=#{project_list}&maxResults=1000")
-
-          all_users << parse_json(response.body)
-        end
+        response  = client.get("/rest/api/2/user/search?username=_&maxResults=#{MAX_RESULTS}")
+        all_users = JSON.parse(response.body)
 
         all_users.flatten.uniq.map do |user|
           client.User.build(user)
         end
       end
-
     end
 
   end

--- a/spec/integration/user_spec.rb
+++ b/spec/integration/user_spec.rb
@@ -24,35 +24,19 @@ describe JIRA::Resource::User do
     describe "#all" do
       let(:client) do
         client = double(options: {rest_base_path: '/jira/rest/api/2'}  )
-        allow(client).to receive(:User).and_return(JIRA::Resource::UserFactory.new(client))
+        allow(client).to receive(:get).with("/rest/api/2/user/search?username=_&maxResults=1000").and_return(JIRA::Resource::UserFactory.new(client))
         client
       end
 
-      let(:project_keys1) { (0...100).to_a.join(",") }
-
-      let(:project_keys2) { (100...200).to_a.join(",") }
-
-      let(:project_keys3) { (200...220).to_a.join(",") }
-
-      projects = 220.times.map.with_index do |i|
-        [OpenStruct.new(key: i.to_s) , OpenStruct.new(key: i.to_s)]
-      end.flatten
-
       before do
-        allow(client).to receive_message_chain(:Project, :all) { projects }
         allow(client).to receive(:get)
-          .with("/jira/rest/api/2/user/assignable/multiProjectSearch?projectKeys=#{project_keys1}&maxResults=1000") { OpenStruct.new(body: '{"users":[]}') }
-        allow(client).to receive(:get)
-          .with("/jira/rest/api/2/user/assignable/multiProjectSearch?projectKeys=#{project_keys2}&maxResults=1000") { OpenStruct.new(body: '{"users":[]}') }
-        allow(client).to receive(:get)
-          .with("/jira/rest/api/2/user/assignable/multiProjectSearch?projectKeys=#{project_keys3}&maxResults=1000") { OpenStruct.new(body: '{"users":[]}') }
-        allow(client).to receive_message_chain(:User, :build).with({"users"=>[]}) { "user" }
+          .with("/rest/api/2/user/search?username=_&maxResults=1000") { OpenStruct.new(body: '["User1"]') }
+        allow(client).to receive_message_chain(:User, :build).with("users") { [] }
       end
 
-      it "splits the projects by 100 and uniqs them to get users on projects" do
-        expect(client).to receive(:get).with("/jira/rest/api/2/user/assignable/multiProjectSearch?projectKeys=#{project_keys1}&maxResults=1000")
-        expect(client).to receive(:get).with("/jira/rest/api/2/user/assignable/multiProjectSearch?projectKeys=#{project_keys2}&maxResults=1000")
-        expect(client).to receive(:get).with("/jira/rest/api/2/user/assignable/multiProjectSearch?projectKeys=#{project_keys3}&maxResults=1000")
+      it "gets users with maxResults of 1000" do
+        expect(client).to receive(:get).with("/rest/api/2/user/search?username=_&maxResults=1000")
+        expect(client).to receive_message_chain(:User, :build).with("User1")
         JIRA::Resource::User.all(client)
       end
     end


### PR DESCRIPTION
Unfortunately, we cannot get more than 1,000 users from the JIRA API see: https://jira.atlassian.com/browse/JRASERVER-65089

However, upon investigating we have found a better way to essentially get all users with one call instead of multiple calls through a parsed project list.

This cleans up the all method in the gem significantly and avoids the issue of not getting all users who are not assigned to all projects.