### PR TITLE
IE 1122 fix jira v2 call

### DIFF
--- a/lib/jira/base_factory.rb
+++ b/lib/jira/base_factory.rb
@@ -38,7 +38,7 @@ module JIRA
     # The principle purpose of this class is to delegate methods to the corresponding
     # non-factory class and automatically prepend the client argument to the argument
     # list.
-    delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql
+    delegate_to_target_class :all, :find, :collection_path, :singular_path, :jql, :jql_v2
 
     # This method needs special handling as it has a default argument value
     def build(attrs={})


### PR DESCRIPTION
Add `jql_v2` call to BaseFactory to fix the error
https://www.mavenlinkintegrations.com/admin/provisioned_accounts/521/logs/1182214078